### PR TITLE
resetTimeout + small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 ganache-log
 parity-log
 
+parity

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 
 tmp/
 
-ethereumjs-vm/
-
 ganache-log
 parity-log
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Then run the tests with:
 truffle test
 ```
 
+## Easy Parity Installation
+
+Download latest binary relase for your OS from [here](https://github.com/paritytech/parity/releases)
+
+You might need to run parity and kill it once if you are getting an issue with accounts.
+
+```
+./parity --chain dev
+```
+
+Kill it. Then do:
+
+```
+./parity --config config.toml --geth
+```
+
+To run the parity dev chain needed for the offchain component.
+
 ## Doge-Ethereum bounty split contract
 
  The bounty contract is deployed at: `0x1ed3e252dcb6d540947d2d63a911f56733d55681`

--- a/contracts/claimManager.sol
+++ b/contracts/claimManager.sol
@@ -26,7 +26,7 @@ contract ClaimManager is DepositsManager {
     event ClaimCreated(uint claimID, address claimant, bytes plaintext, bytes blockHash);
     event ClaimChallenged(uint claimID, address challenger);
     event ClaimVerificationGameStarted(uint claimID, address claimant, address challenger, uint sessionId);
-    event ClaimDecided(uint claimID, address winner, address loser);
+    event SessionDecided(uint sessionId, address winner, address loser);
     event ClaimSuccessful(uint claimID, address claimant, bytes plaintext, bytes blockHash);
     event ClaimVerificationGamesEnded(uint claimID);
 
@@ -177,10 +177,10 @@ contract ClaimManager is DepositsManager {
     // @dev – called when a verification game has ended.
     // only callable by the scryptVerifier contract.
     //
-    // @param claimID – the claim ID.
+    // @param sessionId – the sessionId.
     // @param winner – winner of the verification game.
     // @param loser – loser of the verification game.
-    function claimDecided(uint claimID, address winner, address loser) onlyBy(address(scryptVerifier)) public {
+    function sessionDecided(uint sessionId, uint claimID, address winner, address loser) onlyBy(address(scryptVerifier)) public {
         ScryptClaim storage claim = claims[claimID];
 
         require(claimExists(claim));
@@ -193,7 +193,7 @@ contract ClaimManager is DepositsManager {
         delete claim.bondedDeposits[loser];
         claim.bondedDeposits[winner] = claim.bondedDeposits[winner].add(depositToTransfer);
 
-        ClaimDecided(claimID, winner, loser);
+        SessionDecided(sessionId, winner, loser);
 
         if (claim.claimant == loser) {
             // the claim is over.

--- a/contracts/verifier.sol
+++ b/contracts/verifier.sol
@@ -11,7 +11,7 @@ import {ClaimManager} from "./claimManager.sol";
 */
 contract Verifier {
 
-    event NewClaim(uint sessionId);
+    event NewSession(uint sessionId);
     event NewQuery(uint sessionId);
     event NewResponse(uint sessionId);
     event ChallengerConvicted(uint sessionId);
@@ -67,7 +67,7 @@ contract Verifier {
 
         require(isInitiallyValid(sessions[sessionId]));
 
-        NewClaim(sessionId);
+        NewSession(sessionId);
         return sessionId;
     }
 
@@ -157,6 +157,7 @@ contract Verifier {
 
     function performStepVerification(
         uint sessionId,
+        uint claimID,
         bytes preValue,
         bytes postValue,
         bytes proofs,
@@ -173,10 +174,10 @@ contract Verifier {
         require(keccak256(postValue) == s.highHash);
 
         if (performStepVerificationSpecific(s, s.lowStep, preValue, postValue, proofs)) {
-            claimManager.claimDecided(sessionId, s.claimant, s.challenger);
+            claimManager.sessionDecided(sessionId, claimID, s.claimant, s.challenger);
             challengerConvicted(sessionId);
         } else {
-            claimManager.claimDecided(sessionId, s.challenger, s.claimant);
+            claimManager.sessionDecided(sessionId, claimID, s.challenger, s.claimant);
             claimantConvicted(sessionId);
         }
     }


### PR DESCRIPTION
This PR most importantly gets rid of the two stage challenge lifecycle described in #45. A claim now has a defaultChallengeTimeout, where if no challenges come in, the claim is not decided until then. If someone challenges a claim that will reset the claim's specific timer.

This PR also adds a method for extra safety to check if a claim exists. Ensuring users do not interact with nonexistent claims.

It also fixes parts where the names claim and session are being used synonymously.