### PR TITLE
Adding in .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
The solidity contracts in the scrypt-interactive repo currently don't have syntax highlighting. Github recently added support for solidity syntax highlighting, but due to name conflicts, requires each repo which wants such highlighting to add in a special `.gitattributes` file. This PR adds this file to the scrypt-interactive repo.

Contracts look very nice with highlighting turned on (for example, see https://github.com/datamined/contracts/blob/master/contracts/DataCoin.sol), so I think it will make the contracts here more readable.